### PR TITLE
Update links to current endpoints at wire.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 # Open source
 
-The [privacy page](https://wire.com/privacy/) and the [privacy](https://wire-docs.wire.com/download/Wire+Privacy+Whitepaper.pdf) and [security](https://wire-docs.wire.com/download/Wire+Security+Whitepaper.pdf) whitepapers explain the details of the encryption algorithms and protocols used.
+The [privacy page](https://wire.com/en/legal/terms-of-use-personal/#legal3) and the [privacy](https://wire-docs.wire.com/download/Wire+Privacy+Whitepaper.pdf) and [security](https://wire-docs.wire.com/download/Wire+Security+Whitepaper.pdf) whitepapers explain the details of the encryption algorithms and protocols used.
 
-For licensing information, see the attached LICENSE file and the list of third-party licenses at [wire.com/legal/licenses/](https://wire.com/legal/licenses/).
+For licensing information, see the attached [LICENSE file](LICENSE) and the [list of third-party licenses at wire.com](https://wire.com/en/legal/terms-of-use-personal/#legal5).
 
 If you compile the open source software that we make available from time to time to develop your own mobile, desktop or web application, and cause that application to connect to our servers for any purposes, we refer to that resulting application as an “Open Source App”.  All Open Source Apps are subject to, and may only be used and/or commercialized in accordance with, the Terms of Use applicable to the Wire Application, which can be found at https://wire.com/legal/#terms.  Additionally, if you choose to build an Open Source App, certain restrictions apply, as follows:
 
@@ -74,7 +74,7 @@ You can contribute to Wire in several ways:
 
 ## Finding bugs
 
-If you find a bug in how Wire apps work, please submit a ticket to [our support](https://wire.com/support) and we will keep you informed about the progress.
+If you find a bug in how Wire apps work, please submit a ticket to [our support](https://support.wire.com) and we will keep you informed about the progress.
 
 ## Contributing to the code
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ For licensing information, see the attached LICENSE file and the list of third-p
 
 If you compile the open source software that we make available from time to time to develop your own mobile, desktop or web application, and cause that application to connect to our servers for any purposes, we refer to that resulting application as an “Open Source App”.  All Open Source Apps are subject to, and may only be used and/or commercialized in accordance with, the Terms of Use applicable to the Wire Application, which can be found at https://wire.com/legal/#terms.  Additionally, if you choose to build an Open Source App, certain restrictions apply, as follows:
 
-a. You agree not to change the way the Open Source App connects and interacts with our servers; 
-b. You agree not to weaken any of the security features of the Open Source App; 
-c. You agree not to use our servers to store data for purposes other than the intended and original functionality of the Open Source App; 
-d. You acknowledge that you are solely responsible for any and all updates to your Open Source App. 
+a. You agree not to change the way the Open Source App connects and interacts with our servers;
+b. You agree not to weaken any of the security features of the Open Source App;
+c. You agree not to use our servers to store data for purposes other than the intended and original functionality of the Open Source App;
+d. You acknowledge that you are solely responsible for any and all updates to your Open Source App.
 
 For clarity, if you compile the open source software that we make available from time to time to develop your own mobile, desktop or web application, and do not cause that application to connect to our servers for any purposes, then that application will not be deemed an Open Source App and the foregoing will not apply to that application.
 
@@ -52,7 +52,7 @@ The Axolotl protocol implementation and other cryptographic and utility librarie
 - [proteus](https://github.com/wireapp/proteus): Axolotl Protocol Implementation in Rust, then cross compiled for iOS and Android
 - [cryptobox](https://github.com/wireapp/cryptobox): High-level API with persistent storage for proteus
 - [cryptobox-haskell](https://github.com/wireapp/cryptobox-haskell): Haskell bindings to cryptobox
-- [cryptobox-c](https://github.com/wireapp/cryptobox-c): C-FFI to cryptobox 
+- [cryptobox-c](https://github.com/wireapp/cryptobox-c): C-FFI to cryptobox
 - [hkdf](https://github.com/wireapp/hkdf): HKDF implementation (RFC 5869) in Rust, then cross compiled to iOS and Android
 
 ## Server
@@ -66,7 +66,7 @@ Protocol buffer definitions are used by all clients to communicate with each oth
 ### Repositories
 
 - [generic-message-proto](https://github.com/wireapp/generic-message-proto): Protocol buffer definitions that are part of the cross-platform client communication protocol
-- [backend-api-protobuf](https://github.com/wireapp/backend-api-protobuf): Protocol buffer definitions that are part of the backend communication protocol 
+- [backend-api-protobuf](https://github.com/wireapp/backend-api-protobuf): Protocol buffer definitions that are part of the backend communication protocol
 
 # Contributions
 


### PR DESCRIPTION
Some links used in the document, generated 404s, this PR updates these links to the current endpoints at wire.com.